### PR TITLE
Fix code examples to match rules and edk2 uncrustify style

### DIFF
--- a/3_quick_reference.md
+++ b/3_quick_reference.md
@@ -348,7 +348,7 @@
 
 ```c
 @file [<name>]
-@param[in, out] <parameter name> { parameter description }
+@param[in,out] <parameter name> { parameter description }
 @retval <return value> { description }
 @sa { references }
 @test { description of a test case }

--- a/4_naming_conventions/44_identifiers.md
+++ b/4_naming_conventions/44_identifiers.md
@@ -59,7 +59,7 @@ convention widely used with the C programming language, especially in
 Microsoft* Windows* programming. An example of a non-compliant variable named
 with the Hungarian conventions follows:
 
-```
+```c
 bmRequestType;  // Byte mask, First byte in the USB message header
 pachInsert;     // A pointer to an array of characters to insert.
 ```

--- a/4_naming_conventions/46_name_space_rules.md
+++ b/4_naming_conventions/46_name_space_rules.md
@@ -53,9 +53,9 @@ tags may be reused only for union types.
 
 ```c
 typedef struct MyStruct {
-  UINT32  One;
-  UINT32  Two;
-  UINT32  Three;
+  UINT32    One;
+  UINT32    Two;
+  UINT32    Three;
 } MY_STRUCT;
 ```
 
@@ -68,20 +68,20 @@ Exceptions are structure member and union member names.
 
 ```c
 typedef struct StructOne {
-  INT32             One;
-  INT16             Two;
-  struct StructOne  *MySelf;
+  INT32               One;
+  INT16               Two;
+  struct StructOne    *MySelf;
 } STRUCT_ONE;
 
 typedef struct StructTwo {
-  INT16             One;
-  INT8              *Two;
-  struct StructTwo  *MySelf;
+  INT16               One;
+  INT8                *Two;
+  struct StructTwo    *MySelf;
 } STRUCT_TWO;
 
 typedef struct {
-  STRUCT_ONE  *StructOne;     // NOT ALLOWED
-  STRUCT_TWO  *StructTwoPtr;  // ALLOWED, it is unique
+  STRUCT_ONE    *StructOne;    // NOT ALLOWED
+  STRUCT_TWO    *StructTwoPtr; // ALLOWED, it is unique
 } BAD_STRUCT;
 ```
 

--- a/5_source_files/52_spacing.md
+++ b/5_source_files/52_spacing.md
@@ -73,7 +73,7 @@ This requirement includes functions and data. A _simple predicate expression_
 is one containing zero or one operator which fits on the same line as the
 keyword.
 
-```
+```c
 while (MyVar != 0) {
 ```
 
@@ -126,8 +126,8 @@ if (MyVar != 0) {
 
 #### 5.2.2.3 Do not put space between unary operators and their object
 
-```
-If ((--MyInteger) > 0) {
+```c
+if ((--MyInteger) > 0) {
 ```
 
 #### 5.2.2.4 Subsequent lines of multi-line function calls should line up two spaces from the beginning of the function name
@@ -187,7 +187,7 @@ EfiLibAllocateCopyPool (...
 
 #### 5.2.2.7 Put a space before an open brace if it is not on its own line
 
-```
+```c
 if () {
 while () {
 ```
@@ -201,7 +201,7 @@ Pointer->Index = *Ptr;
 
 #### 5.2.2.9 Do not put spaces before open brackets of array subscripts
 
-```
+```c
 Array[(Max + Min) / 2]
 ```
 
@@ -211,7 +211,7 @@ Array[(Max + Min) / 2]
 
 Consider the following expression:
 
-```
+```c
 8 | 8 == 8
 ```
 
@@ -219,7 +219,7 @@ On first glance, one might think that the expression would evaluate to `TRUE`.
 This is not the case. The bitwise OR operator, '`|`', has lower precedence than
 the equality operator, '`==`'. This results in the expression being evaluated as
 if one had entered:
-```
+```c
 8 | (8 == 8)
 ```
 
@@ -239,7 +239,7 @@ Value = (GetData (BubbaBaes + BUBBA_HIGH_DATA) << 8) |
 This block shall begin on the first line of the file. This is a Doxygen file
 descriptor comment block, so line 1 of the file will be:
 
-```
+```c
 /** @file
 ```
 

--- a/5_source_files/53_include_files.md
+++ b/5_source_files/53_include_files.md
@@ -42,7 +42,7 @@ The name of all include files, within the EDK II code base, must be unique. The
 uniqueness test applies to the entire path used in the #include directive. For
 example:
 
-```
+```c
 #include <Peach/Pit.h>
 #include "Olive/Pit.h"
 #include <MoneyPit.h>

--- a/5_source_files/54_code_file_structure.md
+++ b/5_source_files/54_code_file_structure.md
@@ -141,7 +141,7 @@ declarations whose scope and visibility overlap that of the first declaration.
 The following example shows how the scope visibility of identifiers can overlap
 and hide each other. Never write code that does this.
 
-```
+```c
  1 UINTN MyVar = 7; // File scope
  2
  3 VOID

--- a/5_source_files/55_preprocessor_directives.md
+++ b/5_source_files/55_preprocessor_directives.md
@@ -47,7 +47,7 @@ to include files in the same directory as, or a subdirectory of, the file being
 compiled, and angle brackets for all other include files.
 
 ```c
-#include <Uefi.h> /* System include file. */
+#include <Uefi.h>        /* System include file. */
 #include "SampleThing.h" /* In same directory as the C file. */
 ```
 
@@ -76,9 +76,9 @@ functions.
 An order-of-precedence bug in a macro is very hard to debug. The following are
 examples of macro construction:
 
-```
-#define BAD_MACRO(a, b) a * b
-#define GOOD_MACRO(a, b) ((a) * (b))
+```c
+#define BAD_MACRO(a, b)   a * b
+#define GOOD_MACRO(a, b)  ((a) * (b))
 ```
 
 The following examples should explain the difference between `BAD_MACRO ()` and
@@ -92,7 +92,7 @@ The following examples should explain the difference between `BAD_MACRO ()` and
 
 Also, consider the following expression:
 
-```
+```c
 8 | 8 == 8
 ```
 
@@ -101,14 +101,14 @@ This is not the case. The bitwise OR operator, '`|`', has lower precedence than
 the equality operator, '`==`'. This results in the expression being evaluated as
 if one had entered:
 
-```
+```c
 8 | (8 == 8)
 ```
 
 This evaluates to the value 9 The desired result of `TRUE`, (1), can be achieved
 by specifying the expression as:
 
-```
+```c
 ((8 | 8) == 8)
 ```
 
@@ -122,20 +122,20 @@ or a simple substitution macro.
 
 Failure to do this will cause the build to break.
 
-```
-#define GOOD_MACRO(a, b) ((a) * (b))
+```c
+#define GOOD_MACRO(a, b)  ((a) * (b))
 ```
 
 This is because the compiler has no way to differentiate between
 
-```
-#define SIMPLE_MACRO (a) (TXT)
+```c
+#define SIMPLE_MACRO  (a) (TXT)
 ```
 
 which substitutes all subsequent occurrences of SIMPLE_MACRO with (a) (TXT), and
 
-```
-#define PARAM_MACRO(a) (a) (TXT)
+```c
+#define PARAM_MACRO(a)  (a) (TXT)
 ```
 
 which defines a parameterized macro.
@@ -145,7 +145,7 @@ which defines a parameterized macro.
 Failure to separate macro names from parameters negatively impacts readability
 and consistency with other coding style rules.
 
-```
+```c
 GOOD_MACRO (7 + 3, 2)
 ```
 

--- a/5_source_files/56_declarations_and_types.md
+++ b/5_source_files/56_declarations_and_types.md
@@ -225,7 +225,7 @@ typedef struct EFI_STRUCT_NAME EFI_STRUCT_NAME;
 /// Sample self-referential structure declaration.
 typedef struct EFI_STRUCTURE_NAME {
   ...
-  struct EFI_STRUCTURE_NAME *StructPointer;  ///< Sample self reference
+  struct EFI_STRUCTURE_NAME    *StructPointer; ///< Sample self reference
 } EFI_STRUCT_NAME;
 ```
 
@@ -237,7 +237,7 @@ typedef struct EFI_STRUCTURE_NAME {
   * Detailed description of purpose and use of this structure.
 **/
 typedef struct {
-  Atype  memberOne;  ///< Briefly describe memberOne
+  Atype    memberOne; ///< Briefly describe memberOne
   ...
   Ztype  memberN;    ///< Briefly describe memberN
 } EFI_STRUCTURE_NAME;

--- a/5_source_files/57_c_programming.md
+++ b/5_source_files/57_c_programming.md
@@ -94,17 +94,17 @@ multiples of two spaces.
   @retval  EFI_SUCCESS   Description of what EFI_SUCCESS means.
   @retval  !EFI_SUCCESS  Failure.
 
---*/
+**/
 EFI_STATUS
 EFIAPI
 FooName (
-  IN UINTN      Arg1,
-  IN UINTN      Arg2, OPTIONAL
-  OUT UINTN     *Arg3,
+  IN     UINTN  Arg1,
+  IN     UINTN  Arg2  OPTIONAL,
+  OUT    UINTN  *Arg3,
   IN OUT UINTN  *Arg4
   )
 {
-  UINTN Local;
+  UINTN  Local;
   ...
 }
 ```
@@ -208,9 +208,9 @@ Non-Boolean comparisons must use a compare operator (`==`, `!=`, `>`, `< >=`,
 "Predicate Expression Examples" below shows examples using the following:
 
 ```c
-BOOLEAN Done;
-UINTN Index;
-VOID *Ptr;
+BOOLEAN  Done;
+UINTN    Index;
+VOID     *Ptr;
 ```
 
 ###### Table 10 Predicate Expression Examples
@@ -232,7 +232,7 @@ This is perfectly valid code and, with some compilers, is needed for limit
 checking against enumerated types. These compilers will assign the type to the
 enum based upon the range of values the enum is assigned at compile time.
 
-```
+```c
 if ((foo >= 0) &&
     (foo < MaxVal))
 { ...
@@ -442,7 +442,7 @@ case 2:
 default:
   IamTheCode ();
   break;
-};
+}
 ```
 
 The case statements are indented either zero tab stops or one tab stop and the
@@ -479,15 +479,17 @@ The `goto` follows the normal rules for C code. The label must be indented one
 level less than the code it is marking.
 
 ```c
-Status = IAmTheCode ();
-if (EFI_ERROR (Status)) {
-  goto ErrorExit;
-}
-
-IDoTheWork ();
-
+{
+  Status = IAmTheCode ();
+  if (EFI_ERROR (Status)) {
+    goto ErrorExit;
+  }
+  
+  IDoTheWork ();
+  
 ErrorExit:
   return Status;
+}
 ```
 
 The above example could have been rewritten as below, eliminating the need for
@@ -524,13 +526,13 @@ FooName (
 In any situation, definition of structure instances shall be in the following
 form:
 
-```
+```c
 EFI_STRUCTURE_NAME  StructureName;
 ```
 
 Never pass structures as function parameters by value. Use the "address of"
 operator, '`&`', and pass structures by reference.
 
-```
+```c
 FooName (&StructureName);
 ```

--- a/6_documenting_software/610_special_commands.md
+++ b/6_documenting_software/610_special_commands.md
@@ -121,7 +121,7 @@ documentation.
 Finally, to put invisible comments inside comment blocks, you may use HTML
 style comments:
 
-```
+```c
 /** <!-- This is a comment within a comment block --> Visible text */
 ```
 

--- a/6_documenting_software/64_what_you_must_comment.md
+++ b/6_documenting_software/64_what_you_must_comment.md
@@ -72,8 +72,8 @@ storage duration, and no initializer. (The value assigned could be arbitrary;
 the above-mentioned value is chosen for stylistic reasons.) For example:
 
 ```c
-UINTN LocalIntegerVariable;
-VOID  *LocalPointerVariable;
+UINTN  LocalIntegerVariable;
+VOID   *LocalPointerVariable;
 
 LocalIntegerVariable = 0;
 LocalPointerVariable = NULL;
@@ -85,8 +85,8 @@ an intervening assignment. Therefore, each such assignment must be documented,
 as follows:
 
 ```c
-UINTN LocalIntegerVariable;
-VOID  *LocalPointerVariable;
+UINTN  LocalIntegerVariable;
+VOID   *LocalPointerVariable;
 
 //
 // set LocalIntegerVariable to suppress incorrect compiler/analyzer warnings

--- a/6_documenting_software/65_types_of_comments.md
+++ b/6_documenting_software/65_types_of_comments.md
@@ -44,8 +44,8 @@ comments are almost always special Doxygen comment blocks. See Section 6.6
 
 ```c
 typedef struct {
-  EFI_SAMPLE_STRUCTURE *StructurePointer; ///< Sample comment #1
-  UINT64               SimpleVariable;    ///< Sample comment #2
+  EFI_SAMPLE_STRUCTURE    *StructurePointer; ///< Sample comment #1
+  UINT64                  SimpleVariable;    ///< Sample comment #2
 } EFI_STRUCTURE_NAME;
 ```
 
@@ -89,8 +89,10 @@ readability of the code.
 
 ```c
 /// Do nothing, carefully.
-void
-NoFun (VOID)
+VOID
+NoFun (
+  VOID
+  )
 {
   // Only process data if mTest is TRUE.
   // This comment block applies to the entire if/else statement.
@@ -99,12 +101,12 @@ NoFun (VOID)
     // is appropriate if mTest is true.
     // This comment block only applies when mTest is true.
 
-    ThisIsTheCode();
+    ThisIsTheCode ();
   } else {
     // Explain what we do if (mTest) is false.
     // This comment block only applies when mTest is false.
 
-    ThisIsMoreCode();
+    ThisIsMoreCode ();
   }
 }
 ```

--- a/appendix_a_common_examples.md
+++ b/appendix_a_common_examples.md
@@ -65,7 +65,7 @@
   @param[in]       Arg2  Description of Arg2 This is complicated and requires
                          multiple lines to describe.
   @param[out]      Arg3  Description of Arg3.
-  @param[in, out]  Arg4  Description of Arg4.
+  @param[in,out]   Arg4  Description of Arg4.
 
   @retval  VAL_ONE  Description of what VAL_ONE signifies.
   @retval  OTHER    This is the only other return value. If there were other
@@ -76,8 +76,8 @@ EFI_STATUS
 EFIAPI
 FooBar (
   IN     UINTN  Arg1,
-  IN     UINTN  Arg2, OPTIONAL
-     OUT UINTN  *Arg3,
+  IN     UINTN  Arg2  OPTIONAL,
+  OUT    UINTN  *Arg3,
   IN OUT UINTN  *Arg4
   );
 ```
@@ -95,16 +95,16 @@ typedef enum {
 
 /// Structure without forward reference.
 typedef struct {
-  UINT32                   Signature;  ///< Signature description.
-  EFI_HANDLE               Handle;     ///< Handle description.
-  EFI_PROD_PROT1_PROTOCOL  ProdProt1;  ///< ProdProt1 description.
-  EFI_PROD_PROT2_PROTOCOL  ProdProt2;  ///< ProdProt2 description.
+  UINT32                     Signature; ///< Signature description.
+  EFI_HANDLE                 Handle;    ///< Handle description.
+  EFI_PROD_PROT1_PROTOCOL    ProdProt1; ///< ProdProt1 description.
+  EFI_PROD_PROT2_PROTOCOL    ProdProt2; ///< ProdProt2 description.
 } DRIVER_NAME_INSTANCE;
 
 /// Self referential Structure.
 typedef struct EFI_CPU_IO_PROTO {
-  struct EFI_CPU_IO_PROTO     *Mem;
-  EFI_CPU_IO_PROTOCOL_ACCESS  Io;
+  struct EFI_CPU_IO_PROTO       *Mem;
+  EFI_CPU_IO_PROTOCOL_ACCESS    Io;
 } EFI_CPU_IO_PROTOCOL;
 
 /// Forward reference
@@ -112,8 +112,8 @@ typedef struct StructTag MyStruct;
 
 /// Forward reference target
 struct StructTag {
-  INT32 First;
-  INT32 Second;
+  INT32    First;
+  INT32    Second;
 };
 ```
 
@@ -170,5 +170,5 @@ case 2:
 default:
   IamTheCode ();
   break;
-};
+}
 ```


### PR DESCRIPTION
Fixes #23 

* Update all C code blocks to start with ```c
* Doxygen [in, out] parameter must be [in,out]
* Min 4 spaces between structure field type and field name.
* Min 2 spaces between macro declaration and implementation
* Align function argument type names in same column
* Min 2 spaces between function argument name and OPTIONAL keyword. OPTIONAL keyword must be before ','.
* Min 2 spaces between local variable type and name
* Align function argument names in same column
* Remove extra ; after }
* Add {} to goto example to show indent rules.
* 1 space between called function name and (
* Each parameter in function declaration on own line

Contributed-under: TianoCore Contribution Agreement 1.1