### PR TITLE
Drop 'strong discouragement' of nested block-local variables

### DIFF
--- a/5_source_files/54_code_file_structure.md
+++ b/5_source_files/54_code_file_structure.md
@@ -114,8 +114,9 @@ creating a new scope.
 
 Data declarations may follow the opening brace of a compound statement,
 regardless of nesting depth, and before any code generating statements have
-been entered. Other than at the outermost block of a function body, this type
-of declaration is strongly discouraged.
+been entered. This can be helpful to reduce the number of live variables at
+function scope, but care should be taken that it does not make variable
+scope confusing.
 
 **********
 **Note:** Visual C++ gives all structure declarations File Scope, even though


### PR DESCRIPTION
The rules explicitly permit variable definitions such as
  if (Condition) {
    UINTN Example;
    ...
  }

But for some reason it simultaneously "strongly discourages" from it. This feels entirely wrong to me; the codebase suffers from too-long functions with too many live variables making compilers' work more difficult - preventing optimisations and periodically throwing up warnings/errors as compilers change.

Change the strong discouragement to a note on not confusing variable scope.